### PR TITLE
Add dependency management and setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ pair constraints:
 The `golf_team_optimizer` module provides a simple heuristic implementation
 written in pure Python so it can run without extra dependencies.
 
+## Setup
+
+Install the Python dependencies listed in `requirements.txt` before running the
+code. If you are using Codex you can simply execute the provided setup script:
+
+```bash
+./setup.sh
+```
+
+This installs packages such as `openpyxl`, `pandas`, `streamlit` and `pytest` so
+the application and tests can run offline.
+
 ## Usage
 
 ```python

--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,1 @@
+setup: ./setup.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openpyxl
+pandas
+streamlit
+pytest

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- list required Python packages in `requirements.txt`
- provide `setup.sh` to install dependencies
- configure Codex to run the setup script via `codex.yaml`
- document the setup procedure in the README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*